### PR TITLE
Verify tests pass locally in python 3.5

### DIFF
--- a/idpflex/bayes.py
+++ b/idpflex/bayes.py
@@ -5,7 +5,6 @@ against an experimental profile.
 
 from __future__ import print_function, absolute_import
 
-import numpy as np
 from mantid.simpleapi import (Fit, CreateWorkspace, TabulatedFunction,
                               CompositeFunctionWrapper, FlatBackground)
 
@@ -20,7 +19,7 @@ def model_at_node(node, property_name):
         Any node of a cnextend.Tree
     property_name : str
         name of the property to create the model for.
-    
+
     Returns
     -------
     c : TabulatedFunction + background
@@ -71,7 +70,7 @@ def model_at_depth(tree, depth, property_name):
 
 def do_fit(a_function, experiment, prefix='fit', run_fabada=False):
     r"""Carries out fitting of a model against an experimental profile.
-    
+
     An initial quick fit using Levenberg-Marquardt minimizer is followed
     by a longer minimization using the FABADA minimizer.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==8.1.2
+pip==9.0.1
 bumpversion==0.5.3
 wheel==0.29.0
 watchdog==0.8.3
@@ -10,3 +10,4 @@ cryptography==1.7
 PyYAML==3.11
 pytest==2.9.2
 pytest-runner==2.11.1
+matplotlib==2.1.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
 requirements = [
-    'future', 'scipy', 'numpy', 'six',
+    'future', 'scipy', 'numpy', 'six', 'h5py', 'lmfit'
     # TODO: put package requirements here
 ]
 

--- a/tests/test_bayes.py
+++ b/tests/test_bayes.py
@@ -4,10 +4,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+mantid = pytest.importorskip('mantid')  # skip all test if mantid not found
 from mantid.simpleapi import CreateWorkspace, FlatBackground
 
 from idpflex import bayes
-from idpflex.test.test_helper import sans_benchmark, sans_fit
+from test_helper import sans_benchmark, sans_fit
 
 
 def test_model_at_depth(sans_fit):

--- a/tests/test_cnextend.py
+++ b/tests/test_cnextend.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import
 import pytest
 from scipy.cluster import hierarchy
 
-from idpflex.test.test_helper import benchmark
+from test_helper import benchmark
 from idpflex import cnextend as cnx
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from idpflex import properties as ps
-from idpflex.test.test_helper import benchmark, sans_benchmark, saxs_benchmark
+from test_helper import benchmark, sans_benchmark, saxs_benchmark
 
 
 class TestRegisterDecorateProperties(object):


### PR DESCRIPTION
I had to skip bayes tests as they use `mantid`. In future, switch to `lmfit`
Fixes #3 